### PR TITLE
Allow for multiple environments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ class Envault extends Command {
             return
         }
 
-        const config = await getConfig()
+        const config = await getConfig(args.server, args.environment)
 
         if (! config) this.error('Please initialize your Envault environment before trying to pull.')
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,7 +47,7 @@ export async function getConfig(server = null, environment = null) {
     // If no config found
     if (typeof config === 'undefined') {
         // Default to first config if no server and environment provided
-        if (configs.length && ! server && ! environment) {
+        if ((configs.length) && (! server) && (! environment)) {
             config = configs[0]
         } else {
             return


### PR DESCRIPTION
You can now store multiple environments instead of overwriting when authenticating a new environment.
This will store environments in an array of objects to allow for this.

Now after you've added additional environments you are able to sync a specific `.env` by providing the server and environment ID. This is especially useful if you have multiple `.env` files. Eg.:

**Authentication**
```bash
// Add two environments
npx envault envault.server.test 1 llT8J6tEDbtJgSln 
npx envault envault.server.test 2 BXYtZdNkQjtWSqE6
```

**Syncing**
```
npx envault 												// Will still sync .env from "1"
npx envault envault.server.test 2 --filename=.env.settings  // Will sync .env.settings from "2"
```

If no server and environment provided it will default to the first environment that was added for backwards compatibility.